### PR TITLE
i tags for font libraries were being stripped out of the CKEditor

### DIFF
--- a/admin/assets/ckeditor/config.js
+++ b/admin/assets/ckeditor/config.js
@@ -5,7 +5,11 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 
 CKEDITOR.editorConfig = function( config )
 {
+    config.allowedContent = true;
+    config.extraAllowedContent = 'p(*)[*]{*};div(*)[*]{*};li(*)[*]{*};ul(*)[*]{*}';
 	// Define changes to default configuration here. For example:
 	// config.language = 'fr';
 	// config.uiColor = '#AADC6E';
 };
+// ALLOW <i></i>
+CKEDITOR.dtd.$removeEmpty.i = 0;


### PR DESCRIPTION
CKEditor config.js has been updated to allow i tags for icons like bootstrap and other layout frameworks use. Also removed some of the more draconian restrictions on inserted content.